### PR TITLE
Simplifies `apk add`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,8 +21,7 @@ ENV CHECK_URL=
 ENV FAIL_URL=
 ENV TZ=
 
-RUN apk -U add ca-certificates fuse wget dcron tzdata \
-  && rm -rf /var/cache/apk/*
+RUN apk --no-cache add ca-certificates fuse wget dcron tzdata
 
 RUN URL=http://downloads.rclone.org/${RCLONE_VERSION}/rclone-${RCLONE_VERSION}-linux-${ARCH}.zip ; \
   URL=${URL/\/current/} ; \


### PR DESCRIPTION
* removes the option `-U` (`Maximum AGE (in minutes) for index in cache before refresh` set to 1)
* removes the deletion of the local cache
* adds the option `--no-cache` (`Do not use any local cache path`)