### PR TITLE
Critical: Fix healtcheck reporting ok but rclone failed in case DIR_CHECK, no OUTPUT_LOG.

### DIFF
--- a/sync.sh
+++ b/sync.sh
@@ -55,6 +55,7 @@ else
       export RETURN_CODE=$?
       set -e
     fi
+    echo "INFO: $RCLONE_CMD finished with return code: $RETURN_CODE"
   else
     set e+
     if test "$(rclone --max-depth $RCLONE_DIR_CMD_DEPTH $RCLONE_DIR_CMD "$(eval echo $SYNC_SRC)" $RCLONE_OPTS)"; then
@@ -70,12 +71,14 @@ else
       eval "rclone $RCLONE_CMD $SYNC_SRC $SYNC_DEST $RCLONE_OPTS $SYNC_OPTS_ALL --log-file=${LOG_FILE}"
       export RETURN_CODE=$?
       set -e
+      echo "INFO: $RCLONE_CMD finished with return code: $RETURN_CODE"
     else
       echo "INFO: Starting rclone $RCLONE_CMD $SYNC_SRC $SYNC_DEST $RCLONE_OPTS $SYNC_OPTS_ALL"
       set +e
       eval "rclone $RCLONE_CMD $SYNC_SRC $SYNC_DEST $RCLONE_OPTS $SYNC_OPTS_ALL"
-      set -e
       export RETURN_CODE=$?
+      set -e
+      echo "INFO: $RCLONE_CMD finished with return code: $RETURN_CODE"
     fi
     else
       echo "WARNING: Source directory is empty. Skipping $RCLONE_CMD command."


### PR DESCRIPTION
I had the problem that the healtchecks showed that everything was ok but the backup with rclone failed.

- This fixes the problem that the reported healtcheck is ok despite rclone exiting with an error, i.e. with return code unequal from 0.
- Moreover, it prints the return code for easy inspection of container logs.